### PR TITLE
Updates on publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,6 @@ jobs:
       - name: Release build
         run: ./gradlew :zero_bounce_sdk:assembleRelease
 
-        # Generates other artifacts (javadocJar is optional)
-      - name: Source jar and dokka
-        run: ./gradlew androidSourcesJar javadocJar
-
         # Runs upload, and then closes & releases the repository
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -8,6 +8,12 @@ tasks.withType(dokkaHtmlPartial.getClass()).configureEach {
     )
 }
 
+tasks.register('javadocJar', Jar) {
+    dependsOn dokkaJavadoc
+    archiveClassifier.set('javadoc')
+    from dokkaJavadoc.outputDirectory
+}
+
 group = PUBLISH_GROUP_ID
 version = PUBLISH_VERSION
 
@@ -25,6 +31,8 @@ afterEvaluate {
                 } else {
                     from components.java
                 }
+
+                artifact javadocJar
 
                 pom {
                     name = PUBLISH_ARTIFACT_ID

--- a/zero_bounce_sdk/build.gradle
+++ b/zero_bounce_sdk/build.gradle
@@ -73,7 +73,6 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
         }
     }
 


### PR DESCRIPTION
Because we still use dokka 2.0.0, we need to add javadocJar back. When we'll migrate on dokka v2, we can use the new code for publishing the doc jar.